### PR TITLE
Weapon switching fix - Setting weapon index also in case weapon already exists in inventory …

### DIFF
--- a/player/weapon_pivot.gd
+++ b/player/weapon_pivot.gd
@@ -63,6 +63,7 @@ func _process(_delta: float) -> void:
 func add_weapon(new_weapon: PackedScene) -> void:
 	for weapon_type in _weapons:
 		if weapon_type.resource_path == new_weapon.resource_path:
+			_set_weapon_index(_weapons.find(new_weapon))
 			return
 
 	_weapons.append(new_weapon)


### PR DESCRIPTION
…(typically default weapon player stars with). Player starts with RapidFire weapon by default. Originally when player first picked up different weapon (e.g. IcePunch) and then picked up RapidFire weapon again, weapon index wasn't reset back to RapidFire. Instead player was still using IcePunch.